### PR TITLE
Refactor PauseAsync to avoid redundant calls

### DIFF
--- a/Giyu/Core/Managers/AudioManager.cs
+++ b/Giyu/Core/Managers/AudioManager.cs
@@ -376,15 +376,9 @@ namespace Giyu.Core.Managers
                     return "Player não conectado a um canal de voz.";
                 }
 
-                if (player.PlayerState is PlayerState.Playing)
+                if (player.PlayerState != PlayerState.Playing)
                 {
-                    await player.PauseAsync();
-                }
-
-                if (!(player.PlayerState is PlayerState.Playing))
-                {
-                    await player.PauseAsync();
-                    return $"Não tem música ativa para pausar.";
+                    return "Não tem música ativa para pausar.";
                 }
 
                 await player.PauseAsync();


### PR DESCRIPTION
## Summary
- simplify `AudioManager.PauseAsync` by removing redundant `player.PauseAsync` calls
- warn only when no track is playing and pause once when playback is active

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build` *(no tests found, warnings only)*

------
https://chatgpt.com/codex/tasks/task_e_68963129df308328a92f956770f875c8